### PR TITLE
fix(config): use persistent path for SQLite DB in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,8 +43,10 @@ OPENCLAW_NPM_REGISTRY=
 OPENCLAW_NPM_PACKAGE=
 
 
-# sqlite数据库
-OPENCLAW_DB_URL=sqlite:///tmp/sqlite/enclaws.db
+# SQLite database
+# NOTE: Avoid /tmp — macOS purges /tmp on reboot, causing data loss.
+# Use a persistent path under OPENCLAW_STATE_DIR instead.
+OPENCLAW_DB_URL=sqlite:///Users/<you>/.enclaws/data.db
 # GATEWAY默认端口号
 OPENCLAW_GATEWAY_PORT=18888
 


### PR DESCRIPTION
## Summary
- Replace default SQLite path from `/tmp/sqlite/enclaws.db` to `~/.enclaws/data.db`
- macOS clears `/tmp` on reboot, causing all SQLite data (tenants, users, channels) to be silently lost while filesystem state (`~/.enclaws/tenants/`) remains intact
- Add a NOTE comment warning against using `/tmp` for the database

## Context
After a macOS reboot, the gateway starts with an empty database — no tenants, no users, no channel configs — but reports no errors. This makes the issue hard to diagnose since feishu tools still register but never connect.

## Test plan
- [ ] Copy `.env.example` to `.env`, verify the path comment is clear
- [ ] Confirm gateway reads from the persistent path after restart
- [ ] Reboot macOS, verify data survives

🤖 Generated with [Claude Code](https://claude.ai/claude-code)